### PR TITLE
테스트 환경을 구성한다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ out/
 .env
 *.log
 .DS_Store
+api.yml

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,3 +1,10 @@
+import com.epages.restdocs.apispec.gradle.OpenApi3Task
+import org.gradle.internal.impldep.org.bouncycastle.asn1.x500.style.RFC4519Style.title
+
+plugins {
+    alias(libs.plugins.restdocs.api.spec)
+}
+
 dependencies {
     implementation(project(":domain"))
     implementation(project(":common"))
@@ -9,6 +16,10 @@ dependencies {
     implementation(libs.jakarta.validation)
 
     testImplementation(libs.spring.boot.starter.test)
+    testImplementation(libs.bundles.spring.rest.docs)
+    testFixturesImplementation(libs.bundles.test)
+    testFixturesImplementation(libs.bundles.spring.test)
+    testFixturesImplementation(libs.bundles.spring.rest.docs)
 }
 
 tasks {
@@ -18,5 +29,17 @@ tasks {
 
     jar {
         enabled = false
+    }
+
+    test {
+        finalizedBy(withType<OpenApi3Task>())
+    }
+
+    openapi3 {
+        title = "Gotchai API"
+        version = "v1"
+        format = "yml"
+        outputFileNamePrefix = "api"
+        outputDirectory = "src/main/resources/static/docs"
     }
 }

--- a/api/src/testFixtures/kotlin/com/gotchai/api/common/ControllerTest.kt
+++ b/api/src/testFixtures/kotlin/com/gotchai/api/common/ControllerTest.kt
@@ -1,0 +1,31 @@
+package com.gotchai.api.common
+
+import io.kotest.core.extensions.Extension
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.extensions.spring.SpringExtension
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.restdocs.RestDocumentationContextProvider
+import org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation
+import org.springframework.test.web.servlet.client.MockMvcWebTestClient
+import org.springframework.web.context.WebApplicationContext
+
+@WebMvcTest
+@AutoConfigureRestDocs
+abstract class ControllerTest : DescribeSpec() {
+    override fun extensions(): List<Extension> = listOf(SpringExtension)
+
+    @Autowired
+    private lateinit var webApplicationContext: WebApplicationContext
+
+    @Autowired
+    private lateinit var restDocumentationContextProvider: RestDocumentationContextProvider
+
+    protected val webClient by lazy {
+        MockMvcWebTestClient.bindToApplicationContext(webApplicationContext)
+            .configureClient()
+            .filter(WebTestClientRestDocumentation.documentationConfiguration(restDocumentationContextProvider))
+            .build()
+    }
+}

--- a/api/src/testFixtures/kotlin/com/gotchai/api/docs/CommonDocs.kt
+++ b/api/src/testFixtures/kotlin/com/gotchai/api/docs/CommonDocs.kt
@@ -1,0 +1,19 @@
+package com.gotchai.api.docs
+
+import com.gotchai.api.global.dto.ApiResponse
+import com.gotchai.api.global.dto.ErrorResponse
+import com.gotchai.api.util.bodyDesc
+
+val apiResponseFields =
+    listOf(
+        ApiResponse<*>::success bodyDesc "처리 성공 여부",
+        ApiResponse<*>::status bodyDesc "상태 코드",
+        ApiResponse<*>::data bodyDesc "응답 데이터",
+        ApiResponse<*>::timestamp bodyDesc "타임 스탬프"
+    )
+
+val errorResponseFields =
+    listOf(
+        ErrorResponse::errorCode bodyDesc "에러 코드",
+        ErrorResponse::message bodyDesc "에러 메세지",
+    )

--- a/api/src/testFixtures/kotlin/com/gotchai/api/fixture/CommonFixture.kt
+++ b/api/src/testFixtures/kotlin/com/gotchai/api/fixture/CommonFixture.kt
@@ -1,0 +1,5 @@
+package com.gotchai.api.fixture
+
+import java.time.LocalDateTime
+
+const val ID = 1L

--- a/api/src/testFixtures/kotlin/com/gotchai/api/util/RestDocsUtil.kt
+++ b/api/src/testFixtures/kotlin/com/gotchai/api/util/RestDocsUtil.kt
@@ -1,0 +1,88 @@
+package com.gotchai.api.util
+
+import com.epages.restdocs.apispec.WebTestClientRestDocumentationWrapper
+import com.gotchai.api.docs.apiResponseFields
+import com.gotchai.api.global.dto.ApiResponse
+import org.springframework.restdocs.operation.preprocess.Preprocessors
+import org.springframework.restdocs.payload.FieldDescriptor
+import org.springframework.restdocs.payload.PayloadDocumentation.*
+import org.springframework.restdocs.request.ParameterDescriptor
+import org.springframework.restdocs.request.RequestDocumentation.*
+import org.springframework.restdocs.snippet.Snippet
+import org.springframework.test.web.reactive.server.WebTestClient.BodySpec
+import kotlin.reflect.KProperty
+
+infix fun String.bodyDesc(description: String): FieldDescriptor =
+    fieldWithPath(this)
+        .description(description)
+
+infix fun <T> KProperty<T>.bodyDesc(description: String): FieldDescriptor =
+    fieldWithPath(name)
+        .description(description)
+
+infix fun String.paramDesc(description: String): ParameterDescriptor =
+    parameterWithName(this)
+        .description(description)
+
+fun List<FieldDescriptor>.toListFields(): List<FieldDescriptor> =
+    map { "[].${it.path}" bodyDesc it.description as String }
+
+fun <T> BodySpec<T, *>.document(
+    identifier: String,
+    init: DocumentDsl<T>.() -> Unit,
+): BodySpec<T, *> =
+    DocumentDsl(identifier, this)
+        .apply(init)
+        .build()
+
+class DocumentDsl<T>(
+    private val identifier: String,
+    private val contentSpec: BodySpec<T, *>,
+) {
+    private val snippets: MutableList<Snippet> = mutableListOf()
+
+    fun requestBody(fields: List<FieldDescriptor>) {
+        snippets.add(requestFields(fields))
+    }
+
+    fun requestBody(vararg fields: FieldDescriptor) {
+        snippets.add(requestFields(*fields))
+    }
+
+    fun pathParams(fields: List<ParameterDescriptor>) {
+        snippets.add(pathParameters(fields))
+    }
+
+    fun pathParams(vararg fields: ParameterDescriptor) {
+        snippets.add(pathParameters(*fields))
+    }
+
+    fun queryParams(fields: List<ParameterDescriptor>) {
+        snippets.add(queryParameters(fields))
+    }
+
+    fun queryParams(vararg fields: ParameterDescriptor) {
+        snippets.add(queryParameters(*fields))
+    }
+
+    fun responseBody(fields: List<FieldDescriptor>) {
+        snippets.add(responseFields(mergeWithApiResponseFields(fields)))
+    }
+
+    fun responseBody(vararg fields: FieldDescriptor) {
+        snippets.add(responseFields(mergeWithApiResponseFields(fields.toList())))
+    }
+
+    fun build(): BodySpec<T, *> =
+        contentSpec.consumeWith(
+            WebTestClientRestDocumentationWrapper.document(
+                identifier,
+                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                *snippets.toTypedArray(),
+            )
+        )
+
+    private fun mergeWithApiResponseFields(fields: List<FieldDescriptor>): List<FieldDescriptor> =
+        apiResponseFields + fields.map { "${ApiResponse<*>::data.name}.${it.path}" bodyDesc it.description as String }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,7 @@ subprojects {
     tasks {
         test {
             useJUnitPlatform()
+            classpath += files(sourceSets.main.map { it.output })
         }
     }
 }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,3 +1,4 @@
 dependencies {
     implementation(libs.slf4j)
+    testFixturesImplementation(libs.bundles.test)
 }

--- a/common/src/testFixtures/kotlin/com/gotchai/common/config/ProjectConfig.kt
+++ b/common/src/testFixtures/kotlin/com/gotchai/common/config/ProjectConfig.kt
@@ -1,0 +1,9 @@
+package com.gotchai.common.config
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.spec.IsolationMode
+
+class ProjectConfig : AbstractProjectConfig() {
+    override val parallelism: Int = 3
+    override val isolationMode: IsolationMode = IsolationMode.InstancePerLeaf
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,9 @@ mysql = "8.2.0"
 # AWS
 aws = "2.25.47"
 
+# OpenAPI
+restdocs-api-spec = "0.19.4"
+
 [plugins]
 
 # Java
@@ -48,6 +51,9 @@ spring-dependency-management = { id = "io.spring.dependency-management", version
 # Ktlint
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 
+# OpenAPI
+restdocs-api-spec = { id = "com.epages.restdocs-api-spec", version.ref = "restdocs-api-spec" }
+
 [libraries]
 
 # Kotlin
@@ -63,6 +69,7 @@ spring-boot-starter-aop = { group = "org.springframework.boot", name = "spring-b
 spring-boot-starter-validation = { group = "org.springframework.boot", name = "spring-boot-starter-validation" }
 spring-boot-starter-test = { group = "org.springframework.boot", name = "spring-boot-starter-test" }
 spring-boot-configuration-processor = { group = "org.springframework.boot", name = "spring-boot-configuration-processor", version.ref = "spring-boot" }
+spring-restdocs-webtestclient = { group = "org.springframework.restdocs", name = "spring-restdocs-webtestclient" }
 
 # Jakarta
 jakarta-validation = { group = "jakarta.validation", name = "jakarta.validation-api" }
@@ -95,8 +102,11 @@ h2 = { group = "com.h2database", name = "h2" }
 # AWS
 aws-sdk-s3 = { group = "software.amazon.awssdk", name = "s3", version.ref = "aws" }
 
-[bundles]
+# OpenAPI
+restdocs-api-spec = { group = "com.epages", name = "restdocs-api-spec", version.ref = "restdocs-api-spec" }
+restdocs-api-spec-webtestclient = { group = "com.epages", name = "restdocs-api-spec-webtestclient", version.ref = "restdocs-api-spec" }
 
+[bundles]
 
 aws = ["aws-sdk-s3"]
 jdsl = [
@@ -113,4 +123,9 @@ spring-test = [
     "spring-boot-starter-test",
     "kotest-extensions-spring",
     "spring-mockk"
+]
+spring-rest-docs = [
+    "spring-restdocs-webtestclient",
+    "restdocs-api-spec",
+    "restdocs-api-spec-webtestclient"
 ]


### PR DESCRIPTION
## 관련 이슈
- close #3

## 작업 내용
- Kotest 기반 테스트 환경 구성
- Spring REST Docs 및 OpenAPI 문서화 설정

## 참고
- 컨트롤러 계층 테스트를 수행해서 생성된 Spring REST Docs 기반 OpenAPI 문서는 `api` 모듈 내 `src/main/resources/static/docs`에 저장되도록 했습니다.
- Kotlin 확장 함수 및 직렬화 지원 등의 이점을 생각해 `MockMvc`가 아닌 `WebTestClient`를 컨트롤러 계층 테스트에 사용하도록 했습니다.
  - 이때 사용되는 `WebTestClient`는 `MockMvcWebTestClient`로, `MockMvc`를 단순히 래핑(Wrapping)한 것이므로 따로 리액티브 지원(Reactor Netty 등)이 필요하지 않습니다.
- 테스트 케이스를 3개씩 병렬 처리하고, 테스트 케이스가 서로의 테스트에 영향 받지 않도록 설정했습니다.