### PR TITLE
CI / CD 파이프라인을 구축한다.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,8 +118,7 @@ jobs:
                   "value": "[${{ github.actor }}](${{ github.event.sender.html_url }})",
                   "inline": true
                 } 
-              ],
-              "timestamp": "${{ github.event.workflow_run.updated_at }}"
+              ]
             }
           ]
         }' ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,125 @@
+name: Deploy to AWS EC2
+on:
+  push:
+    branches:
+    - prod
+    - dev
+env:
+  AWS_REGION: ap-northeast-2
+  CONTAINER_NAME: gotchai-server
+  API_SPECIFICATION_PATH: ./api/src/main/resources/static/docs
+jobs:
+  build:
+    name: Deploy API specification
+    runs-on: ubuntu-latest
+    environment: ${{ github.ref_name }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Set up JDK
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: 21
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ env.AWS_REGION }}
+    - name: Create docs directory
+      run: mkdir -p ${{ env.API_SPECIFICATION_PATH }}
+    - name: Run tests
+      run: ./gradlew test
+    - name: Upload API Specification to S3
+      run: aws s3 cp "${{ env.API_SPECIFICATION_PATH }}/api.yml" "s3://${{ secrets.API_SPECIFICATION_BUCKET }}/api.yml"
+  deploy-image:
+    name: Deploy image
+    runs-on: ubuntu-latest
+    environment: ${{ github.ref_name }}
+    needs: build
+    outputs:
+      image: ${{ steps.set-image.outputs.image }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Set up JDK
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: 21
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ env.AWS_REGION }}
+    - name: Set image
+      id: set-image
+      run: echo "image=${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:${{ github.sha }}" >> $GITHUB_OUTPUT
+    - name: Build and deploy image to AWS ECR
+      run: |
+        ./gradlew :api:jib \
+          -Djib.to.image=${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:${{ github.sha }} \
+          -Djib.to.auth.username=AWS \
+          -Djib.to.auth.password=$(aws ecr get-login-password)
+  deploy-container:
+    name: Deploy container
+    runs-on: ubuntu-latest
+    needs: deploy-image
+    environment: ${{ github.ref_name }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build and deploy container to AWS EC2
+      uses: appleboy/ssh-action@v1.0.3
+      with:
+        host: ${{ secrets.EC2_HOST }}
+        username: ${{ secrets.EC2_USER }}
+        key: ${{ secrets.EC2_PRIVATE_KEY }}
+        script: |
+          aws ecr get-login-password | docker login --username AWS --password-stdin ${{ secrets.ECR_REGISTRY }}
+          docker pull ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:${{ github.sha }}
+          docker rm -f ${{ env.CONTAINER_NAME }} || true
+          docker run -d --name ${{ env.CONTAINER_NAME }} -p 8080:8080 ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:${{ github.sha }}
+  notify-discord:
+    name: Notify Discord
+    runs-on: ubuntu-latest
+    needs: deploy-container
+    steps:
+    - name: Send Discord notification
+      run: |
+        curl -X POST -H "Content-Type: application/json" -d '{
+          "username": "GitHub Actions",
+          "avatar_url": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
+          "embeds": [
+            {
+              "title": "**${{ github.ref_name == 'prod' && '프로덕션' || '개발' }} 환경 배포 성공**",
+              "description": "프로젝트가 성공적으로 배포되었습니다.",
+              "color": 3066993,
+              "fields": [
+                {
+                  "name": "Repository",
+                  "value": "[${{ github.repository }}](https://github.com/${{ github.repository }})",
+                  "inline": true
+                },
+                {
+                  "name": "Branch",
+                  "value": "${{ github.ref_name }}",
+                  "inline": true
+                },
+                {
+                  "name": "Commit",
+                  "value": "[${{ github.event.head_commit.message }}](${{ github.event.head_commit.url }})",
+                  "inline": true
+                },
+                {
+                  "name": "Author",
+                  "value": "[${{ github.actor }}](${{ github.event.sender.html_url }})",
+                  "inline": true
+                } 
+              ],
+              "timestamp": "${{ github.event.workflow_run.updated_at }}"
+            }
+          ]
+        }' ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,8 +1,8 @@
 import com.epages.restdocs.apispec.gradle.OpenApi3Task
-import org.gradle.internal.impldep.org.bouncycastle.asn1.x500.style.RFC4519Style.title
 
 plugins {
     alias(libs.plugins.restdocs.api.spec)
+    alias(libs.plugins.jib)
 }
 
 dependencies {
@@ -33,6 +33,12 @@ tasks {
 
     test {
         finalizedBy(withType<OpenApi3Task>())
+    }
+
+    jib {
+        from {
+            image = "openjdk:21-oracle"
+        }
     }
 
     openapi3 {

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -37,7 +37,7 @@ tasks {
 
     jib {
         from {
-            image = "openjdk:21-oracle"
+            image = "amazoncorretto:21-alpine"
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,9 @@ aws = "2.25.47"
 # OpenAPI
 restdocs-api-spec = "0.19.4"
 
+# Jib
+jib = "3.4.0"
+
 [plugins]
 
 # Java
@@ -53,6 +56,9 @@ ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 
 # OpenAPI
 restdocs-api-spec = { id = "com.epages.restdocs-api-spec", version.ref = "restdocs-api-spec" }
+
+# Jib
+jib = { id = "com.google.cloud.tools.jib", version.ref = "jib" }
 
 [libraries]
 


### PR DESCRIPTION
## 관련 이슈
- close #15

## 작업 내용
- CI / CD 파이프라인 구축
- 컨테이너 이미지 빌드에 필요한 Jib 설정

## 참고
- 빌드 과정을 생략하고 이미지를 빌드할 수 있는 Jib를 사용했습니다.
- 테스트 이후 생성된 API 명세서는 AWS S3 버킷에 저장되며, 이후 EC2 인스턴스 내에 배포된 Swagger에서 해당 API 명세서를 읽도록 설계했습니다.
  - Swagger는 수동으로 배포할 예정입니다.
