### PR TITLE
로그아웃, 회원탈퇴, 토큰 재갱신 API를 구현한다.

### DIFF
--- a/api/src/main/kotlin/com/gotchai/api/global/jwt/TokenProcessor.kt
+++ b/api/src/main/kotlin/com/gotchai/api/global/jwt/TokenProcessor.kt
@@ -167,7 +167,7 @@ class TokenProcessor(
         refreshToken: String,
     ): AuthenticationHistory.Info {
         val authenticationHistory =
-            authenticationHistoryReader.readByUserKeyWithDeviceWithRefreshToken(
+            authenticationHistoryReader.readByUserWithDeviceWithRefreshToken(
                 userId = userId,
                 deviceId = deviceId,
                 refreshToken = refreshToken,

--- a/api/src/main/kotlin/com/gotchai/api/presentation/v1/auth/AuthController.kt
+++ b/api/src/main/kotlin/com/gotchai/api/presentation/v1/auth/AuthController.kt
@@ -7,8 +7,10 @@ import com.gotchai.api.presentation.v1.auth.request.LoginRequest
 import com.gotchai.api.presentation.v1.auth.request.LogoutRequest
 import com.gotchai.api.presentation.v1.auth.request.RefreshTokenRequest
 import com.gotchai.api.presentation.v1.auth.request.SignUpRequest
+import com.gotchai.api.presentation.v1.auth.response.LogoutResponse
 import com.gotchai.api.presentation.v1.auth.response.SignUpResponse
 import com.gotchai.api.presentation.v1.auth.response.TokenResponse
+import com.gotchai.api.presentation.v1.auth.response.WithdrawalResponse
 import com.gotchai.common.enum.user.SocialType
 import com.gotchai.domain.auth.AuthenticationFacade
 import com.gotchai.domain.auth.AuthenticationService
@@ -85,16 +87,22 @@ class AuthController(
     @PostMapping("/auth/logout")
     fun logout(
         @RequestBody request: LogoutRequest,
-    ) {
+    ): LogoutResponse {
+        val logout = authenticationService.logout(request.accessToken)
+        return LogoutResponse("로그아웃 되었습니다. userId=$logout")
+    }
+
+    @DeleteMapping("/auth/withdrawal")
+    fun withdrawal(user: User.Issue): WithdrawalResponse {
+        authenticationService.withdrawUser(user.id)
+        return WithdrawalResponse("회원탈퇴가 완료되었습니다.")
     }
 
     @PostMapping("/auth/refresh")
     fun refresh(
         @RequestBody request: RefreshTokenRequest,
-    ) {
-    }
-
-    @DeleteMapping("/auth/withdrawal")
-    fun withdrawal(user: User.Issue) {
+    ): TokenResponse {
+        val token = authenticationService.renew(request.refreshToken)
+        return TokenResponse.of(token)
     }
 }

--- a/api/src/main/kotlin/com/gotchai/api/presentation/v1/auth/response/LogoutResponse.kt
+++ b/api/src/main/kotlin/com/gotchai/api/presentation/v1/auth/response/LogoutResponse.kt
@@ -1,0 +1,5 @@
+package com.gotchai.api.presentation.v1.auth.response
+
+data class LogoutResponse(
+    val message: String,
+)

--- a/api/src/main/kotlin/com/gotchai/api/presentation/v1/auth/response/WithdrawalResponse.kt
+++ b/api/src/main/kotlin/com/gotchai/api/presentation/v1/auth/response/WithdrawalResponse.kt
@@ -1,0 +1,5 @@
+package com.gotchai.api.presentation.v1.auth.response
+
+data class WithdrawalResponse(
+    val message: String,
+)

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -7,6 +7,7 @@ spring:
       - redis.yml
       - rdb.yml
       - authentication.yml
+      - oauth.yml
   web.resources.add-mappings: false
 
 server:

--- a/domain/src/main/kotlin/com/gotchai/domain/auth/AuthenticationHistoryReader.kt
+++ b/domain/src/main/kotlin/com/gotchai/domain/auth/AuthenticationHistoryReader.kt
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component
 class AuthenticationHistoryReader(
     private val authenticationHistoryRepository: AuthenticationHistoryRepository,
 ) {
-    fun readByUserKeyWithDeviceWithRefreshToken(
+    fun readByUserWithDeviceWithRefreshToken(
         userId: Long,
         deviceId: String?,
         refreshToken: String,


### PR DESCRIPTION
## 관련 이슈
- close #23 

## 작업 사항

- d199bc071d7ae26233da5e9895f7749967fd9f10: 로그아웃, 회원탈퇴, 토큰 재갱신 API 구현

## 설명

- 기존에 구현했던 비즈니스 로직에 Presentation Layer 단을 구현했습니다.
