### PR TITLE
뱃지 도메인을 정의한다.

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -25,7 +25,9 @@ dependencies {
     runtimeOnly(libs.jjwt.impl)
 
     testImplementation(libs.spring.boot.starter.test)
+    testImplementation(libs.bundles.spring.test)
     testImplementation(libs.bundles.spring.rest.docs)
+    testImplementation(testFixtures(project(":domain")))
     testFixturesImplementation(libs.bundles.test)
     testFixturesImplementation(libs.bundles.spring.test)
     testFixturesImplementation(libs.bundles.spring.rest.docs)

--- a/api/src/testFixtures/kotlin/com/gotchai/api/fixture/CommonFixture.kt
+++ b/api/src/testFixtures/kotlin/com/gotchai/api/fixture/CommonFixture.kt
@@ -1,3 +1,0 @@
-package com.gotchai.api.fixture
-
-const val ID = 1L

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -3,4 +3,5 @@ dependencies {
     compileOnly(libs.spring.context)
     compileOnly(libs.spring.tx)
     compileOnly(libs.jakarta.annotation.api)
+    testFixturesImplementation(project(":common"))
 }

--- a/domain/src/main/kotlin/com/gotchai/domain/badge/entity/Badge.kt
+++ b/domain/src/main/kotlin/com/gotchai/domain/badge/entity/Badge.kt
@@ -1,0 +1,19 @@
+package com.gotchai.domain.badge.entity
+
+import java.time.LocalDateTime
+
+data class Badge(
+    val id: Long,
+    val examId: Long,
+    val name: String,
+    val description: String,
+    val image: String,
+    val createdAt: LocalDateTime,
+) {
+    data class Creation(
+        val examId: Long,
+        val name: String,
+        val description: String,
+        val image: String,
+    )
+}

--- a/domain/src/main/kotlin/com/gotchai/domain/badge/entity/Rank.kt
+++ b/domain/src/main/kotlin/com/gotchai/domain/badge/entity/Rank.kt
@@ -1,0 +1,7 @@
+package com.gotchai.domain.badge.entity
+
+enum class Rank {
+    GOLD,
+    SILVER,
+    BRONZE
+}

--- a/domain/src/main/kotlin/com/gotchai/domain/badge/entity/UserBadge.kt
+++ b/domain/src/main/kotlin/com/gotchai/domain/badge/entity/UserBadge.kt
@@ -1,0 +1,17 @@
+package com.gotchai.domain.badge.entity
+
+import java.time.LocalDateTime
+
+data class UserBadge(
+    val id: Long,
+    val userId: Long,
+    val badgeId: Long,
+    val rank: Rank,
+    val createdAt: LocalDateTime,
+) {
+    data class Creation(
+        val userId: Long,
+        val badgeId: Long,
+        val rank: Rank,
+    )
+}

--- a/domain/src/testFixtures/kotlin/com/gotchai/domain/fixture/BadgeFixture.kt
+++ b/domain/src/testFixtures/kotlin/com/gotchai/domain/fixture/BadgeFixture.kt
@@ -1,0 +1,43 @@
+package com.gotchai.domain.fixture
+
+import com.gotchai.domain.badge.entity.Badge
+import com.gotchai.domain.badge.entity.Rank
+import com.gotchai.domain.badge.entity.UserBadge
+import java.time.LocalDateTime
+
+private const val NAME = "AI 산타 감별사"
+private const val DESCRIPTION = "크리스마스엔 선물보다 눈치가 중요하다는 걸 증명했어요!"
+private const val IMAGE = "https://gotchai.com/image.png"
+private val RANK = Rank.GOLD
+
+fun createBadge(
+    id: Long = ID,
+    examId: Long = ID,
+    name: String = NAME,
+    description: String = DESCRIPTION,
+    image: String = IMAGE,
+    createdAt: LocalDateTime = CREATED_AT,
+): Badge =
+    Badge(
+        id = id,
+        examId = examId,
+        name = name,
+        description = description,
+        image = image,
+        createdAt = createdAt
+    )
+
+fun createUserBadge(
+    id: Long = ID,
+    userId: Long = ID,
+    badgeId: Long = ID,
+    rank: Rank = RANK,
+    createdAt: LocalDateTime = CREATED_AT,
+): UserBadge =
+    UserBadge(
+        id = id,
+        userId = userId,
+        badgeId = badgeId,
+        rank = rank,
+        createdAt = createdAt
+    )

--- a/domain/src/testFixtures/kotlin/com/gotchai/domain/fixture/CommonFixture.kt
+++ b/domain/src/testFixtures/kotlin/com/gotchai/domain/fixture/CommonFixture.kt
@@ -1,0 +1,6 @@
+package com.gotchai.domain.fixture
+
+import java.time.LocalDateTime
+
+const val ID = 1L
+val CREATED_AT = LocalDateTime.now()!!

--- a/domain/src/testFixtures/kotlin/com/gotchai/domain/fixture/UserFixture.kt
+++ b/domain/src/testFixtures/kotlin/com/gotchai/domain/fixture/UserFixture.kt
@@ -1,0 +1,27 @@
+package com.gotchai.domain.fixture
+
+import com.gotchai.common.enum.user.SocialType
+import com.gotchai.domain.user.User
+import java.time.LocalDateTime
+
+private const val NAME = "정상윤"
+private const val EMAIL = "earlgrey02@apple.com"
+private const val SOCIAL_ID = ""
+private val SOCIAL_TYPE = SocialType.APPLE
+
+fun createUser(
+    id: Long = ID,
+    name: String = NAME,
+    email: String = EMAIL,
+    socialId: String? = SOCIAL_ID,
+    socialType: SocialType = SOCIAL_TYPE,
+    createdAt: LocalDateTime = CREATED_AT,
+): User.Info =
+    User.Info(
+        id = id,
+        name = name,
+        email = email,
+        socialId = socialId,
+        socialType = socialType,
+        createdAt = createdAt
+    )

--- a/storage/rdb/src/main/kotlin/com/gotchai/storage/rdb/badge/entity/BadgeEntity.kt
+++ b/storage/rdb/src/main/kotlin/com/gotchai/storage/rdb/badge/entity/BadgeEntity.kt
@@ -1,0 +1,37 @@
+package com.gotchai.storage.rdb.badge.entity
+
+import com.gotchai.domain.badge.entity.Badge
+import com.gotchai.storage.rdb.global.common.BaseEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "badge")
+class BadgeEntity(
+    val examId: Long,
+    val name: String,
+    val description: String,
+    val image: String,
+) : BaseEntity() {
+    companion object {
+        fun from(creation: Badge.Creation): BadgeEntity =
+            with(creation) {
+                BadgeEntity(
+                    examId = examId,
+                    name = name,
+                    description = description,
+                    image = image
+                )
+            }
+    }
+
+    fun toBadge(): Badge =
+        Badge(
+            id = id!!,
+            examId = examId,
+            name = name,
+            description = description,
+            image = image,
+            createdAt = createdAt,
+        )
+}

--- a/storage/rdb/src/main/kotlin/com/gotchai/storage/rdb/badge/entity/UserBadgeEntity.kt
+++ b/storage/rdb/src/main/kotlin/com/gotchai/storage/rdb/badge/entity/UserBadgeEntity.kt
@@ -11,7 +11,7 @@ class UserBadgeEntity(
     val userId: Long,
     val badgeId: Long,
     @Enumerated(value = EnumType.STRING)
-    @Column(name = "provider", columnDefinition = "varchar(50)")
+    @Column(name = "rank", columnDefinition = "varchar(20)")
     val rank: Rank,
 ) : BaseEntity() {
     companion object {

--- a/storage/rdb/src/main/kotlin/com/gotchai/storage/rdb/badge/entity/UserBadgeEntity.kt
+++ b/storage/rdb/src/main/kotlin/com/gotchai/storage/rdb/badge/entity/UserBadgeEntity.kt
@@ -1,0 +1,36 @@
+package com.gotchai.storage.rdb.badge.entity
+
+import com.gotchai.domain.badge.entity.Rank
+import com.gotchai.domain.badge.entity.UserBadge
+import com.gotchai.storage.rdb.global.common.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "user_badge")
+class UserBadgeEntity(
+    val userId: Long,
+    val badgeId: Long,
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "provider", columnDefinition = "varchar(50)")
+    val rank: Rank,
+) : BaseEntity() {
+    companion object {
+        fun from(creation: UserBadge.Creation): UserBadgeEntity =
+            with(creation) {
+                UserBadgeEntity(
+                    userId = userId,
+                    badgeId = badgeId,
+                    rank = rank
+                )
+            }
+    }
+
+    fun toUserBadge(): UserBadge =
+        UserBadge(
+            id = id!!,
+            userId = userId,
+            badgeId = badgeId,
+            rank = rank,
+            createdAt = createdAt,
+        )
+}


### PR DESCRIPTION
## 관련 이슈
- close #21

## 작업 사항
- 뱃지 도메인 관련 엔티티 구현

## 설명
- 도메인 엔티티에서 사용하던 기존의 `Info`를 삭제해봤습니다.