### PR TITLE
테스트 오류를 해결한다.

### DIFF
--- a/api/src/main/kotlin/com/gotchai/api/presentation/v1/badge/BadgeController.kt
+++ b/api/src/main/kotlin/com/gotchai/api/presentation/v1/badge/BadgeController.kt
@@ -2,7 +2,7 @@ package com.gotchai.api.presentation.v1.badge
 
 import com.gotchai.api.global.annotation.ApiV1Controller
 import com.gotchai.api.presentation.v1.badge.response.BadgeResponse
-import com.gotchai.api.presentation.v1.badge.response.GetMyBadgeResponse
+import com.gotchai.api.presentation.v1.badge.response.GetMyBadgeListResponse
 import com.gotchai.domain.badge.port.`in`.BadgeQueryUseCase
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
@@ -25,8 +25,8 @@ class BadgeController(
     fun getMyBadges(
         @AuthenticationPrincipal
         userId: Long
-    ): List<GetMyBadgeResponse> =
+    ): GetMyBadgeListResponse =
         badgeQueryUseCase
             .getMyBadges(userId)
-            .map { GetMyBadgeResponse.from(it) }
+            .let { GetMyBadgeListResponse.from(it) }
 }

--- a/api/src/main/kotlin/com/gotchai/api/presentation/v1/badge/response/GetMyBadgeListResponse.kt
+++ b/api/src/main/kotlin/com/gotchai/api/presentation/v1/badge/response/GetMyBadgeListResponse.kt
@@ -1,0 +1,12 @@
+package com.gotchai.api.presentation.v1.badge.response
+
+import com.gotchai.domain.badge.dto.result.GetMyBadgeResult
+
+data class GetMyBadgeListResponse(
+    val list: List<GetMyBadgeResponse>
+) {
+    companion object {
+        fun from(results: List<GetMyBadgeResult>): GetMyBadgeListResponse =
+            GetMyBadgeListResponse(list = results.map { GetMyBadgeResponse.from(it) })
+    }
+}

--- a/api/src/test/kotlin/com/gotchai/api/presentation/v1/badge/BadgeControllerTest.kt
+++ b/api/src/test/kotlin/com/gotchai/api/presentation/v1/badge/BadgeControllerTest.kt
@@ -3,14 +3,13 @@ package com.gotchai.api.presentation.v1.badge
 import com.gotchai.api.common.ControllerTest
 import com.gotchai.api.docs.badgeResponseFields
 import com.gotchai.api.docs.errorResponseFields
-import com.gotchai.api.docs.getMyBadgeResponseFields
+import com.gotchai.api.docs.getMyBadgeListResponseFields
 import com.gotchai.api.global.dto.ApiResponse
 import com.gotchai.api.presentation.v1.badge.response.BadgeResponse
-import com.gotchai.api.presentation.v1.badge.response.GetMyBadgeResponse
+import com.gotchai.api.presentation.v1.badge.response.GetMyBadgeListResponse
 import com.gotchai.api.util.document
 import com.gotchai.api.util.expectError
 import com.gotchai.api.util.paramDesc
-import com.gotchai.api.util.toListFields
 import com.gotchai.domain.badge.exception.BadgeNotFoundException
 import com.gotchai.domain.badge.port.`in`.BadgeQueryUseCase
 import com.gotchai.domain.fixture.ID
@@ -84,9 +83,9 @@ class BadgeControllerTest : ControllerTest() {
                         .exchange()
                         .expectStatus()
                         .isOk
-                        .expectBody<ApiResponse<List<GetMyBadgeResponse>>>()
+                        .expectBody<ApiResponse<GetMyBadgeListResponse>>()
                         .document("내가 취득한 뱃지 리스트 조회 성공(200)") {
-                            responseBody(getMyBadgeResponseFields.toListFields())
+                            responseBody(getMyBadgeListResponseFields)
                         }
                 }
             }

--- a/api/src/test/kotlin/com/gotchai/api/presentation/v1/exam/ExamControllerTest.kt
+++ b/api/src/test/kotlin/com/gotchai/api/presentation/v1/exam/ExamControllerTest.kt
@@ -3,14 +3,13 @@ package com.gotchai.api.presentation.v1.exam
 import com.gotchai.api.common.ControllerTest
 import com.gotchai.api.docs.errorResponseFields
 import com.gotchai.api.docs.examDetailResponseFields
-import com.gotchai.api.docs.examResponseFields
+import com.gotchai.api.docs.examListResponseFields
 import com.gotchai.api.global.dto.ApiResponse
 import com.gotchai.api.presentation.v1.exam.response.ExamDetailResponse
-import com.gotchai.api.presentation.v1.exam.response.ExamResponse
+import com.gotchai.api.presentation.v1.exam.response.ExamListResponse
 import com.gotchai.api.util.document
 import com.gotchai.api.util.expectError
 import com.gotchai.api.util.paramDesc
-import com.gotchai.api.util.toListFields
 import com.gotchai.domain.exam.port.`in`.ExamQueryUseCase
 import com.gotchai.domain.fixture.ID
 import com.gotchai.domain.fixture.createExam
@@ -28,7 +27,7 @@ class ExamControllerTest : ControllerTest() {
 
     init {
         describe("getExams()는") {
-            context("시험 목록이 존재하는 경우") {
+            context("테스트 목록이 존재하는 경우") {
                 val exams =
                     listOf(
                         createExam(id = 1L, title = "AI와 크리스마스 파티"),
@@ -37,39 +36,25 @@ class ExamControllerTest : ControllerTest() {
 
                 every { examQueryUseCase.getExams() } returns exams
 
-                it("상태 코드 200과 ExamResponse 리스트를 반환한다.") {
+                it("상태 코드 200과 ExamListResponse를 반환한다.") {
                     webClient
                         .get()
                         .uri("/api/v1/exams")
                         .exchange()
                         .expectStatus()
                         .isOk
-                        .expectBody<ApiResponse<List<ExamResponse>>>()
+                        .expectBody<ApiResponse<ExamListResponse>>()
                         .document("시험 목록 조회 성공(200)") {
-                            responseBody(examResponseFields.toListFields())
+                            responseBody(examListResponseFields)
                         }
-                }
-            }
-
-            context("시험 목록이 비어있는 경우") {
-                every { examQueryUseCase.getExams() } returns emptyList()
-
-                it("상태 코드 200과 빈 리스트를 반환한다.") {
-                    webClient
-                        .get()
-                        .uri("/api/v1/exams")
-                        .exchange()
-                        .expectStatus()
-                        .isOk
-                        .expectBody<ApiResponse<List<ExamResponse>>>()
                 }
             }
         }
 
         describe("getExamById()는") {
-            context("조회하려는 시험이 존재하는 경우") {
-                val examResult = createGetExamResult()
-                every { examQueryUseCase.getExamById(ID) } returns examResult
+            context("조회하려는 테스트가 존재하는 경우") {
+                val result = createGetExamResult()
+                every { examQueryUseCase.getExamById(ID) } returns result
 
                 it("상태 코드 200과 ExamDetailResponse를 반환한다.") {
                     webClient
@@ -86,7 +71,7 @@ class ExamControllerTest : ControllerTest() {
                 }
             }
 
-            context("조회하려는 시험이 존재하지 않는 경우") {
+            context("조회하려는 테스트가 존재하지 않는 경우") {
                 every { examQueryUseCase.getExamById(any()) } throws NotFoundDataException()
 
                 it("상태 코드 404와 ErrorResponse를 반환한다.") {

--- a/api/src/testFixtures/kotlin/com/gotchai/api/docs/AuthDocs.kt
+++ b/api/src/testFixtures/kotlin/com/gotchai/api/docs/AuthDocs.kt
@@ -6,30 +6,31 @@ import com.gotchai.api.presentation.v1.auth.request.RefreshRequest
 import com.gotchai.api.presentation.v1.auth.response.RefreshResponse
 import com.gotchai.api.presentation.v1.auth.response.SocialLoginResponse
 import com.gotchai.api.util.bodyDesc
+import com.gotchai.api.util.fieldsOf
 
 val appleLoginRequestFields =
-    listOf(
+    fieldsOf(
         AppleLoginRequest::idToken bodyDesc "ID 토큰"
     )
 
 val kakaoLoginRequestFields =
-    listOf(
+    fieldsOf(
         KakaoLoginRequest::accessToken bodyDesc "카카오 액세스 토큰"
     )
 
 val refreshRequestFields =
-    listOf(
+    fieldsOf(
         RefreshRequest::refreshToken bodyDesc "리프레시 토큰"
     )
 
 val refreshResponseFields =
-    listOf(
+    fieldsOf(
         RefreshResponse::accessToken bodyDesc "액세스 토큰",
         RefreshResponse::refreshToken bodyDesc "리프레시 토큰"
     )
 
 val socialLoginResponseFields =
-    listOf(
+    fieldsOf(
         SocialLoginResponse::accessToken bodyDesc "액세스 토큰",
         SocialLoginResponse::refreshToken bodyDesc "리프레시 토큰"
     )

--- a/api/src/testFixtures/kotlin/com/gotchai/api/docs/BadgeDocs.kt
+++ b/api/src/testFixtures/kotlin/com/gotchai/api/docs/BadgeDocs.kt
@@ -3,9 +3,11 @@ package com.gotchai.api.docs
 import com.gotchai.api.presentation.v1.badge.response.BadgeResponse
 import com.gotchai.api.presentation.v1.badge.response.GetMyBadgeResponse
 import com.gotchai.api.util.bodyDesc
+import com.gotchai.api.util.fieldsOf
+import com.gotchai.api.util.listFieldsOf
 
 val badgeResponseFields =
-    listOf(
+    fieldsOf(
         BadgeResponse::id bodyDesc "식별자",
         BadgeResponse::examId bodyDesc "테스트 식별자",
         BadgeResponse::name bodyDesc "이름",
@@ -15,8 +17,9 @@ val badgeResponseFields =
         BadgeResponse::createdAt bodyDesc "생성 날짜"
     )
 
-val getMyBadgeResponseFields =
-    listOf(
+val getMyBadgeListResponseFields =
+    listFieldsOf(
+        description = "뱃지 리스트",
         GetMyBadgeResponse::id bodyDesc "식별자",
         GetMyBadgeResponse::examId bodyDesc "테스트 식별자",
         GetMyBadgeResponse::name bodyDesc "이름",

--- a/api/src/testFixtures/kotlin/com/gotchai/api/docs/CommonDocs.kt
+++ b/api/src/testFixtures/kotlin/com/gotchai/api/docs/CommonDocs.kt
@@ -3,16 +3,17 @@ package com.gotchai.api.docs
 import com.gotchai.api.global.dto.ApiResponse
 import com.gotchai.api.global.dto.ErrorResponse
 import com.gotchai.api.util.bodyDesc
+import com.gotchai.api.util.fieldsOf
 
 val apiResponseFields =
-    listOf(
+    fieldsOf(
         ApiResponse<*>::isSuccess bodyDesc "처리 성공 여부",
         ApiResponse<*>::status bodyDesc "상태 코드",
         ApiResponse<*>::timestamp bodyDesc "타임 스탬프"
     )
 
 val errorResponseFields =
-    listOf(
+    fieldsOf(
         ErrorResponse::errorCode bodyDesc "에러 코드",
         ErrorResponse::message bodyDesc "에러 메세지"
     )

--- a/api/src/testFixtures/kotlin/com/gotchai/api/docs/ExamDocs.kt
+++ b/api/src/testFixtures/kotlin/com/gotchai/api/docs/ExamDocs.kt
@@ -3,9 +3,12 @@ package com.gotchai.api.docs
 import com.gotchai.api.presentation.v1.exam.response.ExamDetailResponse
 import com.gotchai.api.presentation.v1.exam.response.ExamResponse
 import com.gotchai.api.util.bodyDesc
+import com.gotchai.api.util.fieldsOf
+import com.gotchai.api.util.listFieldsOf
 
-val examResponseFields =
-    listOf(
+val examListResponseFields =
+    listFieldsOf(
+        description = "테스트 리스트",
         ExamResponse::id bodyDesc "식별자",
         ExamResponse::title bodyDesc "제목",
         ExamResponse::subTitle bodyDesc "부제목",
@@ -16,7 +19,7 @@ val examResponseFields =
     )
 
 val examDetailResponseFields =
-    listOf(
+    fieldsOf(
         ExamDetailResponse::id bodyDesc "식별자",
         ExamDetailResponse::title bodyDesc "제목",
         ExamDetailResponse::subTitle bodyDesc "부제목",

--- a/api/src/testFixtures/kotlin/com/gotchai/api/docs/UserDocs.kt
+++ b/api/src/testFixtures/kotlin/com/gotchai/api/docs/UserDocs.kt
@@ -1,3 +1,0 @@
-package com.gotchai.api.docs
-
-class UserDocs

--- a/api/src/testFixtures/kotlin/com/gotchai/api/util/RestDocsUtil.kt
+++ b/api/src/testFixtures/kotlin/com/gotchai/api/util/RestDocsUtil.kt
@@ -24,11 +24,13 @@ infix fun String.paramDesc(description: String): ParameterDescriptor =
     parameterWithName(this)
         .description(description)
 
-fun List<FieldDescriptor>.toListFields(): List<FieldDescriptor> =
-    map {
-        "[].${it.path}" bodyDesc
-            it.description as String
-    }
+fun fieldsOf(vararg field: FieldDescriptor): List<FieldDescriptor> = field.asList()
+
+fun listFieldsOf(
+    description: String,
+    vararg field: FieldDescriptor
+): List<FieldDescriptor> =
+    field.map { "list[].${it.path}" bodyDesc it.description as String } + ("list" bodyDesc description)
 
 fun <T> BodySpec<T, *>.document(
     identifier: String,
@@ -86,18 +88,12 @@ class DocumentDsl<T>(
             )
         )
 
-    private fun mergeWithApiResponseFields(fields: List<FieldDescriptor>): List<FieldDescriptor> {
-        val isArray = fields.all { it.path.startsWith("[]") }
-        val dataField = "${ApiResponse<*>::data.name}${"[]".takeIf { isArray }.orEmpty()}" bodyDesc "응답 데이터"
+    private fun mergeWithApiResponseFields(fields: List<FieldDescriptor>): List<FieldDescriptor> =
+        apiResponseFields +
+            fields.map {
+                val path = "${ApiResponse<*>::data.name}.${it.path}"
+                val description = it.description as String
 
-        return (
-            apiResponseFields + dataField +
-                fields.map {
-                    val path = ApiResponse<*>::data.name + ".".takeUnless { isArray }.orEmpty() + it.path
-                    val description = it.description as String
-
-                    path bodyDesc description
-                }
-        )
-    }
+                path bodyDesc description
+            }
 }

--- a/common/logging/src/main/resources/application-logging.yml
+++ b/common/logging/src/main/resources/application-logging.yml
@@ -1,2 +1,2 @@
 logging:
-  config: classpath:logback/logback-${SPRING_PROFILES_ACTIVE}.xml
+  config: classpath:logback/logback-${SPRING_PROFILES_ACTIVE:local}.xml


### PR DESCRIPTION
## 관련 이슈
- close #48

## 작업 사항
- 실패한 테스트 수정
- 내가 취득한 뱃지 조회 API 명세 변경
- 변경된 리스트 응답 구조(`ExamListResponse` 등)에 대한 문서화 스니펫 및 Spring REST Docs 유틸 수정

## 설명
- 새로운 문서화용 유틸 `fieldsOf()`와 `listFieldsOf()`를 구현했습니다.
  - `fieldsOf()`는 기존의 `listOf()`와 동일하며, `listFieldsOf()`는 리스트 응답 전용으로서 추가했습니다.
- `List<GetMyBadgeResponse>`를 `GetMyBadgeListResponse`로 수정했습니다.