### PR TITLE
테스트 조회 중 풀었던 테스트 여부 필드 추가한다.

### DIFF
--- a/api/src/main/kotlin/com/gotchai/api/presentation/v1/exam/ExamController.kt
+++ b/api/src/main/kotlin/com/gotchai/api/presentation/v1/exam/ExamController.kt
@@ -18,7 +18,7 @@ class ExamController(
     fun getExams(
         @AuthenticationPrincipal
         userId: Long
-    ): ExamListResponse = ExamListResponse.from(examQueryUseCase.getExams())
+    ): ExamListResponse = ExamListResponse.from(examQueryUseCase.getExams(userId))
 
     @GetMapping("/exams/{examId}")
     fun getExamById(
@@ -26,7 +26,7 @@ class ExamController(
         userId: Long,
         @PathVariable
         examId: Long
-    ): ExamResponse = ExamResponse.from(examQueryUseCase.getExamById(examId))
+    ): ExamResponse = ExamResponse.from(examQueryUseCase.getExamById(userId, examId))
 
     @GetMapping("/users/me/exams/solved")
     fun getMyExams(

--- a/api/src/main/kotlin/com/gotchai/api/presentation/v1/exam/response/ExamListResponse.kt
+++ b/api/src/main/kotlin/com/gotchai/api/presentation/v1/exam/response/ExamListResponse.kt
@@ -1,11 +1,11 @@
 package com.gotchai.api.presentation.v1.exam.response
 
-import com.gotchai.domain.exam.entity.Exam
+import com.gotchai.domain.exam.dto.result.ExamResult
 
 data class ExamListResponse(
     val list: List<ExamResponse>
 ) {
     companion object {
-        fun from(exams: List<Exam>): ExamListResponse = ExamListResponse(exams.map { ExamResponse.from(it) })
+        fun from(exams: List<ExamResult>): ExamListResponse = ExamListResponse(exams.map { ExamResponse.from(it) })
     }
 }

--- a/api/src/test/kotlin/com/gotchai/api/presentation/v1/exam/ExamControllerTest.kt
+++ b/api/src/test/kotlin/com/gotchai/api/presentation/v1/exam/ExamControllerTest.kt
@@ -44,7 +44,7 @@ class ExamControllerTest : ControllerTest() {
                     .isOk
                     .expectBody<ApiResponse<ExamListResponse>>()
                     .document("테스트 리스트 조회 성공(200)") {
-                        responseBody(examResultListResponseFields)
+                        responseBody(examListResponseFields)
                     }
             }
         }
@@ -61,7 +61,7 @@ class ExamControllerTest : ControllerTest() {
                     .isOk
                     .expectBody<ApiResponse<ExamListResponse>>()
                     .document("내가 푼 테스트 리스트 조회 성공(200)") {
-                        responseBody(examResultListResponseFields)
+                        responseBody(examListResponseFields)
                     }
             }
         }
@@ -80,7 +80,7 @@ class ExamControllerTest : ControllerTest() {
                         .expectBody<ApiResponse<ExamResponse>>()
                         .document("테스트 단일 조회 성공(200)") {
                             pathParams("examId" paramDesc "테스트 식별자")
-                            responseBody(examResultResponseFields)
+                            responseBody(examResponseFields)
                         }
                 }
             }

--- a/api/src/test/kotlin/com/gotchai/api/presentation/v1/exam/ExamControllerTest.kt
+++ b/api/src/test/kotlin/com/gotchai/api/presentation/v1/exam/ExamControllerTest.kt
@@ -15,7 +15,7 @@ import com.gotchai.domain.exam.exception.ExamNotFoundException
 import com.gotchai.domain.exam.port.`in`.ExamCommandUseCase
 import com.gotchai.domain.exam.port.`in`.ExamQueryUseCase
 import com.gotchai.domain.fixture.ID
-import com.gotchai.domain.fixture.createExam
+import com.gotchai.domain.fixture.createExamResult
 import com.gotchai.domain.fixture.createStartExamResult
 import com.gotchai.domain.fixture.createSubmitExamResult
 import com.ninjasquad.springmockk.MockkBean
@@ -32,8 +32,8 @@ class ExamControllerTest : ControllerTest() {
     private lateinit var examCommandUseCase: ExamCommandUseCase
 
     init {
-        describe("getExams()는") {
-            every { examQueryUseCase.getExams() } returns listOf(createExam())
+        describe("getExams(userId)는") {
+            every { examQueryUseCase.getExams(ID) } returns listOf(createExamResult())
 
             it("상태 코드 200과 ExamListResponse를 반환한다.") {
                 webClient
@@ -44,13 +44,13 @@ class ExamControllerTest : ControllerTest() {
                     .isOk
                     .expectBody<ApiResponse<ExamListResponse>>()
                     .document("테스트 리스트 조회 성공(200)") {
-                        responseBody(examListResponseFields)
+                        responseBody(examResultListResponseFields)
                     }
             }
         }
 
-        describe("getMyExams()는") {
-            every { examQueryUseCase.getExamsByUserId(ID) } returns listOf(createExam())
+        describe("getMyExams(userId)는") {
+            every { examQueryUseCase.getExamsByUserId(ID) } returns listOf(createExamResult())
 
             it("상태 코드 200과 ExamListResponse를 반환한다.") {
                 webClient
@@ -61,14 +61,14 @@ class ExamControllerTest : ControllerTest() {
                     .isOk
                     .expectBody<ApiResponse<ExamListResponse>>()
                     .document("내가 푼 테스트 리스트 조회 성공(200)") {
-                        responseBody(examListResponseFields)
+                        responseBody(examResultListResponseFields)
                     }
             }
         }
 
-        describe("getExamById()는") {
+        describe("getExamById(examId, userId)는") {
             context("조회하려는 테스트가 존재하는 경우") {
-                every { examQueryUseCase.getExamById(ID) } returns createExam()
+                every { examQueryUseCase.getExamById(ID, ID) } returns createExamResult()
 
                 it("상태 코드 200과 ExamResponse를 반환한다.") {
                     webClient
@@ -80,13 +80,13 @@ class ExamControllerTest : ControllerTest() {
                         .expectBody<ApiResponse<ExamResponse>>()
                         .document("테스트 단일 조회 성공(200)") {
                             pathParams("examId" paramDesc "테스트 식별자")
-                            responseBody(examResponseFields)
+                            responseBody(examResultResponseFields)
                         }
                 }
             }
 
             context("조회하려는 테스트가 존재하지 않는 경우") {
-                every { examQueryUseCase.getExamById(any()) } throws ExamNotFoundException()
+                every { examQueryUseCase.getExamById(any(), any()) } throws ExamNotFoundException()
 
                 it("상태 코드 404와 ErrorResponse를 반환한다.") {
                     webClient
@@ -104,7 +104,7 @@ class ExamControllerTest : ControllerTest() {
             }
         }
 
-        describe("getExamParticipantCount()는") {
+        describe("getExamParticipantCount(examId)는") {
             every { examQueryUseCase.getExamParticipantCountById(ID) } returns PARTICIPANT_COUNT
 
             it("상태 코드 200과 GetExamParticipantCountResponse를 반환한다.") {

--- a/api/src/testFixtures/kotlin/com/gotchai/api/docs/ExamDocs.kt
+++ b/api/src/testFixtures/kotlin/com/gotchai/api/docs/ExamDocs.kt
@@ -20,20 +20,6 @@ val examResponseFields =
         ExamResponse::iconImage bodyDesc "아이콘 이미지 URI",
         ExamResponse::coverImage bodyDesc "테스트 커버 이미지 URI",
         ExamResponse::theme bodyDesc "테마",
-        ExamResponse::createdAt bodyDesc "생성 날짜"
-    )
-
-val examResultResponseFields =
-    fieldsOf(
-        ExamResponse::id bodyDesc "식별자",
-        ExamResponse::title bodyDesc "제목",
-        ExamResponse::subTitle bodyDesc "부제목",
-        ExamResponse::description bodyDesc "테스트 설명",
-        ExamResponse::prompt bodyDesc "테스트 프롬프트",
-        ExamResponse::backgroundImage bodyDesc "설명 이미지 URI",
-        ExamResponse::iconImage bodyDesc "아이콘 이미지 URI",
-        ExamResponse::coverImage bodyDesc "테스트 커버 이미지 URI",
-        ExamResponse::theme bodyDesc "테마",
         ExamResponse::isSolved bodyDesc "테스트 풀이 여부",
         ExamResponse::createdAt bodyDesc "생성 날짜"
     )
@@ -42,11 +28,6 @@ val examListResponseFields =
     listFieldsOf(
         "list" bodyDesc "테스트 리스트",
         *examResponseFields.toTypedArray()
-    )
-val examResultListResponseFields =
-    listFieldsOf(
-        "list" bodyDesc "테스트 리스트",
-        *examResultResponseFields.toTypedArray()
     )
 
 val getExamParticipantCountResponseFields =

--- a/api/src/testFixtures/kotlin/com/gotchai/api/docs/ExamDocs.kt
+++ b/api/src/testFixtures/kotlin/com/gotchai/api/docs/ExamDocs.kt
@@ -23,10 +23,30 @@ val examResponseFields =
         ExamResponse::createdAt bodyDesc "생성 날짜"
     )
 
+val examResultResponseFields =
+    fieldsOf(
+        ExamResponse::id bodyDesc "식별자",
+        ExamResponse::title bodyDesc "제목",
+        ExamResponse::subTitle bodyDesc "부제목",
+        ExamResponse::description bodyDesc "테스트 설명",
+        ExamResponse::prompt bodyDesc "테스트 프롬프트",
+        ExamResponse::backgroundImage bodyDesc "설명 이미지 URI",
+        ExamResponse::iconImage bodyDesc "아이콘 이미지 URI",
+        ExamResponse::coverImage bodyDesc "테스트 커버 이미지 URI",
+        ExamResponse::theme bodyDesc "테마",
+        ExamResponse::isSolved bodyDesc "테스트 풀이 여부",
+        ExamResponse::createdAt bodyDesc "생성 날짜"
+    )
+
 val examListResponseFields =
     listFieldsOf(
         "list" bodyDesc "테스트 리스트",
         *examResponseFields.toTypedArray()
+    )
+val examResultListResponseFields =
+    listFieldsOf(
+        "list" bodyDesc "테스트 리스트",
+        *examResultResponseFields.toTypedArray()
     )
 
 val getExamParticipantCountResponseFields =

--- a/domain/src/main/kotlin/com/gotchai/domain/exam/adapter/in/ExamQueryService.kt
+++ b/domain/src/main/kotlin/com/gotchai/domain/exam/adapter/in/ExamQueryService.kt
@@ -18,14 +18,22 @@ class ExamQueryService(
         userId: Long,
         examId: Long
     ): ExamResult =
-        examQueryPort.getExamResultsByUserIdAndExamId(userId, examId)
-            ?: throw ExamNotFoundException()
+        ExamResult.from(
+            examQueryPort.getExamResultsByUserIdAndExamId(userId, examId)
+                ?: throw ExamNotFoundException()
+        )
 
     @Transactional(readOnly = true)
-    override fun getExams(userId: Long): List<ExamResult> = examQueryPort.getExamResultsByUserId(userId)
+    override fun getExams(userId: Long): List<ExamResult> =
+        examQueryPort
+            .getExamResultsByUserId(userId)
+            .map { ExamResult.from(it) }
 
     @Transactional(readOnly = true)
-    override fun getExamsByUserId(userId: Long): List<ExamResult> = examQueryPort.getExamResultsByUserIdWithSolvedStatus(userId, true)
+    override fun getExamsByUserId(userId: Long): List<ExamResult> =
+        examQueryPort
+            .getExamResultsByUserIdWithSolvedStatus(userId, true)
+            .map { ExamResult.from(it) }
 
     @Transactional(readOnly = true)
     override fun getExamParticipantCountById(examId: Long): Int =

--- a/domain/src/main/kotlin/com/gotchai/domain/exam/adapter/in/ExamQueryService.kt
+++ b/domain/src/main/kotlin/com/gotchai/domain/exam/adapter/in/ExamQueryService.kt
@@ -17,47 +17,15 @@ class ExamQueryService(
     override fun getExamById(
         userId: Long,
         examId: Long
-    ): ExamResult {
-        val exam = examQueryPort.getExamById(examId) ?: throw ExamNotFoundException()
-        val examHistory = examHistoryQueryPort.getExamHistoryByExamIdAndUserId(examId, userId)
-        val isSolved = examHistory?.isSolved ?: false
-
-        return ExamResult.of(
-            exam = exam,
-            isSolved = isSolved
-        )
-    }
+    ): ExamResult =
+        examQueryPort.getExamResultsByUserIdAndExamId(userId, examId)
+            ?: throw ExamNotFoundException()
 
     @Transactional(readOnly = true)
-    override fun getExams(userId: Long): List<ExamResult> {
-        val exams = examQueryPort.getExams()
-        val examHistories = examHistoryQueryPort.getExamHistoriesByUserIdAndSolvedTrue(userId)
-        val solvedExamIds = examHistories.map { it.id }
-
-        return exams.map { exam ->
-            val solved = solvedExamIds.contains(exam.id)
-            ExamResult.of(
-                exam = exam,
-                isSolved = solved
-            )
-        }
-    }
+    override fun getExams(userId: Long): List<ExamResult> = examQueryPort.getExamResultsByUserId(userId)
 
     @Transactional(readOnly = true)
-    override fun getExamsByUserId(userId: Long): List<ExamResult> {
-        val examHistories = examHistoryQueryPort.getExamHistoriesByUserIdAndSolvedTrue(userId)
-        val exams = examQueryPort.getExamsByInIn(examHistories.map { it.id })
-
-        val solvedExamIds = examHistories.map { it.id }
-
-        return exams.map { exam ->
-            val solved = solvedExamIds.contains(exam.id)
-            ExamResult.of(
-                exam = exam,
-                isSolved = solved
-            )
-        }
-    }
+    override fun getExamsByUserId(userId: Long): List<ExamResult> = examQueryPort.getExamResultsByUserIdWithSolvedStatus(userId, true)
 
     @Transactional(readOnly = true)
     override fun getExamParticipantCountById(examId: Long): Int =

--- a/domain/src/main/kotlin/com/gotchai/domain/exam/adapter/in/ExamQueryService.kt
+++ b/domain/src/main/kotlin/com/gotchai/domain/exam/adapter/in/ExamQueryService.kt
@@ -1,32 +1,62 @@
 package com.gotchai.domain.exam.adapter.`in`
 
-import com.gotchai.domain.exam.entity.Exam
+import com.gotchai.domain.exam.dto.result.ExamResult
 import com.gotchai.domain.exam.exception.ExamNotFoundException
 import com.gotchai.domain.exam.port.`in`.ExamQueryUseCase
 import com.gotchai.domain.exam.port.out.ExamHistoryQueryPort
 import com.gotchai.domain.exam.port.out.ExamQueryPort
-import com.gotchai.domain.quiz.port.out.QuizQueryPort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class ExamQueryService(
     private val examQueryPort: ExamQueryPort,
-    private val examHistoryQueryPort: ExamHistoryQueryPort,
-    private val quizQueryPort: QuizQueryPort
+    private val examHistoryQueryPort: ExamHistoryQueryPort
 ) : ExamQueryUseCase {
     @Transactional(readOnly = true)
-    override fun getExamById(examId: Long): Exam = examQueryPort.getExamById(examId) ?: throw ExamNotFoundException()
+    override fun getExamById(
+        userId: Long,
+        examId: Long
+    ): ExamResult {
+        val exam = examQueryPort.getExamById(examId) ?: throw ExamNotFoundException()
+        val examHistory = examHistoryQueryPort.getExamHistoryByExamIdAndUserId(examId, userId)
+        val isSolved = examHistory?.isSolved ?: false
+
+        return ExamResult.of(
+            exam = exam,
+            isSolved = isSolved
+        )
+    }
 
     @Transactional(readOnly = true)
-    override fun getExams(): List<Exam> = examQueryPort.getExams()
+    override fun getExams(userId: Long): List<ExamResult> {
+        val exams = examQueryPort.getExams()
+        val examHistories = examHistoryQueryPort.getExamHistoriesByUserIdAndSolvedTrue(userId)
+        val solvedExamIds = examHistories.map { it.id }
+
+        return exams.map { exam ->
+            val solved = solvedExamIds.contains(exam.id)
+            ExamResult.of(
+                exam = exam,
+                isSolved = solved
+            )
+        }
+    }
 
     @Transactional(readOnly = true)
-    override fun getExamsByUserId(userId: Long): List<Exam> {
+    override fun getExamsByUserId(userId: Long): List<ExamResult> {
         val examHistories = examHistoryQueryPort.getExamHistoriesByUserIdAndSolvedTrue(userId)
         val exams = examQueryPort.getExamsByInIn(examHistories.map { it.id })
 
-        return exams
+        val solvedExamIds = examHistories.map { it.id }
+
+        return exams.map { exam ->
+            val solved = solvedExamIds.contains(exam.id)
+            ExamResult.of(
+                exam = exam,
+                isSolved = solved
+            )
+        }
     }
 
     @Transactional(readOnly = true)

--- a/domain/src/main/kotlin/com/gotchai/domain/exam/dto/result/ExamResult.kt
+++ b/domain/src/main/kotlin/com/gotchai/domain/exam/dto/result/ExamResult.kt
@@ -1,6 +1,6 @@
 package com.gotchai.domain.exam.dto.result
 
-import com.gotchai.domain.exam.entity.Exam
+import com.gotchai.domain.exam.entity.ExamWithIsSolved
 import java.time.LocalDateTime
 
 data class ExamResult(
@@ -17,11 +17,8 @@ data class ExamResult(
     val createdAt: LocalDateTime
 ) {
     companion object {
-        fun of(
-            exam: Exam,
-            isSolved: Boolean
-        ): ExamResult =
-            with(exam) {
+        fun from(examWithIsSolved: ExamWithIsSolved): ExamResult =
+            with(examWithIsSolved) {
                 ExamResult(
                     id = id,
                     title = title,

--- a/domain/src/main/kotlin/com/gotchai/domain/exam/dto/result/ExamResult.kt
+++ b/domain/src/main/kotlin/com/gotchai/domain/exam/dto/result/ExamResult.kt
@@ -1,9 +1,9 @@
-package com.gotchai.api.presentation.v1.exam.response
+package com.gotchai.domain.exam.dto.result
 
-import com.gotchai.domain.exam.dto.result.ExamResult
+import com.gotchai.domain.exam.entity.Exam
 import java.time.LocalDateTime
 
-data class ExamResponse(
+data class ExamResult(
     val id: Long,
     val title: String,
     val subTitle: String,
@@ -17,9 +17,12 @@ data class ExamResponse(
     val createdAt: LocalDateTime
 ) {
     companion object {
-        fun from(result: ExamResult): ExamResponse =
-            with(result) {
-                ExamResponse(
+        fun of(
+            exam: Exam,
+            isSolved: Boolean
+        ): ExamResult =
+            with(exam) {
+                ExamResult(
                     id = id,
                     title = title,
                     subTitle = subTitle,

--- a/domain/src/main/kotlin/com/gotchai/domain/exam/entity/ExamWithIsSolved.kt
+++ b/domain/src/main/kotlin/com/gotchai/domain/exam/entity/ExamWithIsSolved.kt
@@ -1,0 +1,17 @@
+package com.gotchai.domain.exam.entity
+
+import java.time.LocalDateTime
+
+data class ExamWithIsSolved(
+    val id: Long,
+    val title: String,
+    val subTitle: String,
+    val description: String,
+    val prompt: String,
+    val backgroundImage: String,
+    val iconImage: String,
+    val coverImage: String,
+    val theme: String,
+    val isSolved: Boolean,
+    val createdAt: LocalDateTime
+)

--- a/domain/src/main/kotlin/com/gotchai/domain/exam/port/in/ExamQueryUseCase.kt
+++ b/domain/src/main/kotlin/com/gotchai/domain/exam/port/in/ExamQueryUseCase.kt
@@ -1,13 +1,16 @@
 package com.gotchai.domain.exam.port.`in`
 
-import com.gotchai.domain.exam.entity.Exam
+import com.gotchai.domain.exam.dto.result.ExamResult
 
 interface ExamQueryUseCase {
-    fun getExamById(examId: Long): Exam
+    fun getExamById(
+        userId: Long,
+        examId: Long
+    ): ExamResult
 
-    fun getExams(): List<Exam>
+    fun getExams(userId: Long): List<ExamResult>
 
-    fun getExamsByUserId(userId: Long): List<Exam>
+    fun getExamsByUserId(userId: Long): List<ExamResult>
 
     fun getExamParticipantCountById(examId: Long): Int
 }

--- a/domain/src/main/kotlin/com/gotchai/domain/exam/port/out/ExamQueryPort.kt
+++ b/domain/src/main/kotlin/com/gotchai/domain/exam/port/out/ExamQueryPort.kt
@@ -1,7 +1,7 @@
 package com.gotchai.domain.exam.port.out
 
-import com.gotchai.domain.exam.dto.result.ExamResult
 import com.gotchai.domain.exam.entity.Exam
+import com.gotchai.domain.exam.entity.ExamWithIsSolved
 
 interface ExamQueryPort {
     fun getExamById(id: Long): Exam?
@@ -11,14 +11,14 @@ interface ExamQueryPort {
     fun getExamResultsByUserIdAndExamId(
         userId: Long,
         examId: Long
-    ): ExamResult?
+    ): ExamWithIsSolved?
 
-    fun getExamResultsByUserId(userId: Long): List<ExamResult>
+    fun getExamResultsByUserId(userId: Long): List<ExamWithIsSolved>
 
     fun getExamsByInIn(ids: Collection<Long>): List<Exam>
 
     fun getExamResultsByUserIdWithSolvedStatus(
         userId: Long,
         isSolved: Boolean
-    ): List<ExamResult>
+    ): List<ExamWithIsSolved>
 }

--- a/domain/src/main/kotlin/com/gotchai/domain/exam/port/out/ExamQueryPort.kt
+++ b/domain/src/main/kotlin/com/gotchai/domain/exam/port/out/ExamQueryPort.kt
@@ -1,5 +1,6 @@
 package com.gotchai.domain.exam.port.out
 
+import com.gotchai.domain.exam.dto.result.ExamResult
 import com.gotchai.domain.exam.entity.Exam
 
 interface ExamQueryPort {
@@ -7,5 +8,17 @@ interface ExamQueryPort {
 
     fun getExams(): List<Exam>
 
+    fun getExamResultsByUserIdAndExamId(
+        userId: Long,
+        examId: Long
+    ): ExamResult?
+
+    fun getExamResultsByUserId(userId: Long): List<ExamResult>
+
     fun getExamsByInIn(ids: Collection<Long>): List<Exam>
+
+    fun getExamResultsByUserIdWithSolvedStatus(
+        userId: Long,
+        isSolved: Boolean
+    ): List<ExamResult>
 }

--- a/domain/src/testFixtures/kotlin/com/gotchai/domain/fixture/ExamFixture.kt
+++ b/domain/src/testFixtures/kotlin/com/gotchai/domain/fixture/ExamFixture.kt
@@ -1,6 +1,7 @@
 package com.gotchai.domain.fixture
 
 import com.gotchai.domain.badge.entity.Badge
+import com.gotchai.domain.exam.dto.result.ExamResult
 import com.gotchai.domain.exam.dto.result.StartExamResult
 import com.gotchai.domain.exam.dto.result.SubmitExamResult
 import com.gotchai.domain.exam.entity.Exam
@@ -39,6 +40,33 @@ fun createExam(
         iconImage = iconImage,
         coverImage = coverImage,
         theme = theme,
+        createdAt = createdAt
+    )
+
+fun createExamResult(
+    id: Long = ID,
+    title: String = TITLE,
+    subTitle: String = SUB_TITLE,
+    description: String = DESCRIPTION,
+    prompt: String = PROMPT,
+    backgroundImage: String = BACKGROUND_IMAGE,
+    iconImage: String = ICON_IMAGE,
+    coverImage: String = COVER_IMAGE,
+    theme: String = THEME,
+    isSolved: Boolean = false,
+    createdAt: LocalDateTime = CREATED_AT
+): ExamResult =
+    ExamResult(
+        id = id,
+        title = title,
+        subTitle = subTitle,
+        description = description,
+        prompt = prompt,
+        backgroundImage = backgroundImage,
+        iconImage = iconImage,
+        coverImage = coverImage,
+        theme = theme,
+        isSolved = isSolved,
         createdAt = createdAt
     )
 

--- a/storage/rdb/src/main/kotlin/com/gotchai/storage/rdb/exam/adapter/out/ExamQueryAdapter.kt
+++ b/storage/rdb/src/main/kotlin/com/gotchai/storage/rdb/exam/adapter/out/ExamQueryAdapter.kt
@@ -1,31 +1,90 @@
 package com.gotchai.storage.rdb.exam.adapter.out
 
+import com.gotchai.domain.exam.dto.result.ExamResult
 import com.gotchai.domain.exam.entity.Exam
 import com.gotchai.domain.exam.port.out.ExamQueryPort
+import com.gotchai.storage.rdb.exam.entity.ExamEntity
+import com.gotchai.storage.rdb.exam.entity.ExamHistoryEntity
 import com.gotchai.storage.rdb.exam.repository.ExamJpaRepository
 import com.gotchai.storage.rdb.global.annotation.Adapter
 import com.gotchai.storage.rdb.global.annotation.ReadOnlyTransactional
+import com.gotchai.storage.rdb.global.util.JdslUtil
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.support.spring.data.jpa.extension.createQuery
+import jakarta.persistence.EntityManager
 import org.springframework.data.repository.findByIdOrNull
 
 @Adapter
 class ExamQueryAdapter(
+    private val entityManager: EntityManager,
+    private val jdslRenderContext: RenderContext,
     private val examJpaRepository: ExamJpaRepository
 ) : ExamQueryPort {
     @ReadOnlyTransactional
-    override fun getExamById(id: Long): Exam? =
-        examJpaRepository
-            .findByIdOrNull(id)
-            ?.toExam()
+    override fun getExamById(id: Long): Exam? = examJpaRepository.findByIdOrNull(id)?.toExam()
 
     @ReadOnlyTransactional
-    override fun getExams(): List<Exam> =
-        examJpaRepository
-            .findAll()
-            .map { it.toExam() }
+    override fun getExams(): List<Exam> = examJpaRepository.findAll().map { it.toExam() }
 
     @ReadOnlyTransactional
-    override fun getExamsByInIn(ids: Collection<Long>): List<Exam> =
-        examJpaRepository
-            .findByIdIn(ids)
-            .map { it.toExam() }
+    override fun getExamResultsByUserId(userId: Long): List<ExamResult> =
+        createExamResultQuery(
+            userId = userId
+        )
+
+    @ReadOnlyTransactional
+    override fun getExamResultsByUserIdAndExamId(
+        userId: Long,
+        examId: Long
+    ): ExamResult? =
+        createExamResultQuery(
+            userId = userId,
+            examId = examId
+        ).firstOrNull()
+
+    @ReadOnlyTransactional
+    override fun getExamsByInIn(ids: Collection<Long>): List<Exam> = examJpaRepository.findByIdIn(ids).map { it.toExam() }
+
+    @ReadOnlyTransactional
+    override fun getExamResultsByUserIdWithSolvedStatus(
+        userId: Long,
+        isSolved: Boolean
+    ): List<ExamResult> =
+        createExamResultQuery(
+            userId = userId,
+            isSolved = isSolved
+        )
+
+    private fun createExamResultQuery(
+        userId: Long,
+        examId: Long? = null,
+        isSolved: Boolean? = null
+    ): List<ExamResult> {
+        val query =
+            jpql(JdslUtil) {
+                selectNew<ExamResult>(
+                    path(ExamEntity::id),
+                    path(ExamEntity::title),
+                    path(ExamEntity::subTitle),
+                    path(ExamEntity::description),
+                    path(ExamEntity::prompt),
+                    path(ExamEntity::backgroundImage),
+                    path(ExamEntity::iconImage),
+                    path(ExamEntity::coverImage),
+                    path(ExamEntity::theme),
+                    coalesce(path(ExamHistoryEntity::isSolved), false),
+                    path(ExamEntity::createdAt)
+                ).from(
+                    entity(ExamEntity::class),
+                    leftJoin(ExamHistoryEntity::class).on(
+                        path(ExamHistoryEntity::examId)
+                            .eq(path(ExamEntity::id))
+                            .and(path(ExamHistoryEntity::userId).eq(userId))
+                            .apply { if (isSolved != null) and(path(ExamHistoryEntity::isSolved).eq(isSolved)) }
+                    )
+                ).apply { if (examId != null) where(path(ExamEntity::id).eq(examId)) }
+            }
+        return entityManager.createQuery(query, jdslRenderContext).resultList
+    }
 }

--- a/storage/rdb/src/main/kotlin/com/gotchai/storage/rdb/exam/adapter/out/ExamQueryAdapter.kt
+++ b/storage/rdb/src/main/kotlin/com/gotchai/storage/rdb/exam/adapter/out/ExamQueryAdapter.kt
@@ -1,7 +1,7 @@
 package com.gotchai.storage.rdb.exam.adapter.out
 
-import com.gotchai.domain.exam.dto.result.ExamResult
 import com.gotchai.domain.exam.entity.Exam
+import com.gotchai.domain.exam.entity.ExamWithIsSolved
 import com.gotchai.domain.exam.port.out.ExamQueryPort
 import com.gotchai.storage.rdb.exam.entity.ExamEntity
 import com.gotchai.storage.rdb.exam.entity.ExamHistoryEntity
@@ -28,7 +28,7 @@ class ExamQueryAdapter(
     override fun getExams(): List<Exam> = examJpaRepository.findAll().map { it.toExam() }
 
     @ReadOnlyTransactional
-    override fun getExamResultsByUserId(userId: Long): List<ExamResult> =
+    override fun getExamResultsByUserId(userId: Long): List<ExamWithIsSolved> =
         createExamResultQuery(
             userId = userId
         )
@@ -37,7 +37,7 @@ class ExamQueryAdapter(
     override fun getExamResultsByUserIdAndExamId(
         userId: Long,
         examId: Long
-    ): ExamResult? =
+    ): ExamWithIsSolved? =
         createExamResultQuery(
             userId = userId,
             examId = examId
@@ -50,7 +50,7 @@ class ExamQueryAdapter(
     override fun getExamResultsByUserIdWithSolvedStatus(
         userId: Long,
         isSolved: Boolean
-    ): List<ExamResult> =
+    ): List<ExamWithIsSolved> =
         createExamResultQuery(
             userId = userId,
             isSolved = isSolved
@@ -60,10 +60,10 @@ class ExamQueryAdapter(
         userId: Long,
         examId: Long? = null,
         isSolved: Boolean? = null
-    ): List<ExamResult> {
+    ): List<ExamWithIsSolved> {
         val query =
             jpql(JdslUtil) {
-                selectNew<ExamResult>(
+                selectNew<ExamWithIsSolved>(
                     path(ExamEntity::id),
                     path(ExamEntity::title),
                     path(ExamEntity::subTitle),


### PR DESCRIPTION
## 관련 이슈
- close #86 

## 작업 사항

- 기존 도메인 엔티티 Exam에서 ExamResult로 변경하여 return 하도록 수정했습니다.
- exam 조회 시 examHistory도 요구사항에 따라 조회하는 로직을 추가하였습니다.
- examHistory는 examId, userId와 같은 조건으로 조회하기에 커버링 인덱스를 걸도록 추후 수정할 듯합니다.