### PR TITLE
중복된 Bean 설정을 삭제한다.

### DIFF
--- a/api/src/main/kotlin/com/gotchai/api/global/jwt/JwtAuthenticationFilter.kt
+++ b/api/src/main/kotlin/com/gotchai/api/global/jwt/JwtAuthenticationFilter.kt
@@ -7,10 +7,8 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.HttpHeaders
 import org.springframework.security.core.context.SecurityContextHolder
-import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 
-@Component
 class JwtAuthenticationFilter(
     private val tokenProvider: TokenProvider
 ) : OncePerRequestFilter() {


### PR DESCRIPTION
## 관련 이슈
- close #97

## 작업 사항
- 중복으로 정의된 Bean 설정 삭제

## 설명
- 테스트에서 `JwtAuthenticationFilter`를 Bean으로 불러오는 문제를 해결하는 PR입니다.