### PR TITLE
유저가 취득한 뱃지 삭제 API를 구현한다.

### DIFF
--- a/api/src/main/kotlin/com/gotchai/api/presentation/v1/admin/AdminController.kt
+++ b/api/src/main/kotlin/com/gotchai/api/presentation/v1/admin/AdminController.kt
@@ -31,4 +31,14 @@ class AdminController(
     ) {
         adminCommandUseCase.deleteExamHistoryByExamIdAndUserId(examId, userId)
     }
+
+    @DeleteMapping("/admin/users/{userId}/badges/{badgeId}")
+    fun deleteUserBadge(
+        @PathVariable
+        userId: Long,
+        @PathVariable
+        badgeId: Long
+    ) {
+        adminCommandUseCase.deleteUserBadgeByBadgeIdAndUserId(userId, badgeId)
+    }
 }

--- a/api/src/test/kotlin/com/gotchai/api/presentation/v1/admin/AdminControllerTest.kt
+++ b/api/src/test/kotlin/com/gotchai/api/presentation/v1/admin/AdminControllerTest.kt
@@ -2,6 +2,7 @@ package com.gotchai.api.presentation.v1.admin
 
 import com.gotchai.api.common.ControllerTest
 import com.gotchai.api.docs.createExamRequestFields
+import com.gotchai.api.docs.errorResponseFields
 import com.gotchai.api.docs.examResponseFields
 import com.gotchai.api.fixture.createCreateExamRequest
 import com.gotchai.api.global.dto.ApiResponse
@@ -11,6 +12,7 @@ import com.gotchai.api.util.desc
 import com.gotchai.api.util.document
 import com.gotchai.api.util.expectError
 import com.gotchai.domain.admin.port.`in`.AdminCommandUseCase
+import com.gotchai.domain.badge.exception.UserBadgeNotFoundException
 import com.gotchai.domain.exam.exception.ExamHistoryNotFoundException
 import com.gotchai.domain.fixture.ID
 import com.gotchai.domain.fixture.createExam
@@ -87,6 +89,50 @@ class AdminControllerTest : ControllerTest() {
                                 "userId" desc "유저 식별자",
                                 "examId" desc "테스트 식별자"
                             )
+                            responseBody(errorResponseFields)
+                        }
+                }
+            }
+        }
+
+        describe("deleteUserBadge()는") {
+            context("유저가 취득한 뱃지가 존재하는 경우") {
+                every { adminCommandUseCase.deleteUserBadgeByBadgeIdAndUserId(ID, ID) } just runs
+
+                it("상태 코드 200을 반환한다.") {
+                    webClient
+                        .delete()
+                        .uri("/api/v1/admin/users/{userId}/badges/{badgeId}", ID, ID)
+                        .exchange()
+                        .expectStatus()
+                        .isOk
+                        .expectBody<Void>()
+                        .document("유저가 취득한 뱃지 삭제 성공(200)") {
+                            pathParams(
+                                "userId" desc "유저 식별자",
+                                "badgeId" desc "뱃지 식별자"
+                            )
+                        }
+                }
+            }
+
+            context("유저가 취득한 뱃지가 존재하지 않는 경우") {
+                every { adminCommandUseCase.deleteUserBadgeByBadgeIdAndUserId(ID, ID) } throws UserBadgeNotFoundException()
+
+                it("상태 코드 404를 반환한다.") {
+                    webClient
+                        .delete()
+                        .uri("/api/v1/admin/users/{userId}/badges/{badgeId}", ID, ID)
+                        .exchange()
+                        .expectStatus()
+                        .isNotFound
+                        .expectError()
+                        .document("유저가 취득한 뱃지 삭제 실패(404)") {
+                            pathParams(
+                                "userId" desc "유저 식별자",
+                                "badgeId" desc "뱃지 식별자"
+                            )
+                            responseBody(errorResponseFields)
                         }
                 }
             }

--- a/domain/src/main/kotlin/com/gotchai/domain/admin/adapter/in/AdminCommandService.kt
+++ b/domain/src/main/kotlin/com/gotchai/domain/admin/adapter/in/AdminCommandService.kt
@@ -3,6 +3,9 @@ package com.gotchai.domain.admin.adapter.`in`
 import com.gotchai.domain.admin.dto.command.CreateExamCommand
 import com.gotchai.domain.admin.exception.InvalidFileException
 import com.gotchai.domain.admin.port.`in`.AdminCommandUseCase
+import com.gotchai.domain.badge.exception.UserBadgeNotFoundException
+import com.gotchai.domain.badge.port.out.UserBadgeCommandPort
+import com.gotchai.domain.badge.port.out.UserBadgeQueryPort
 import com.gotchai.domain.exam.entity.Exam
 import com.gotchai.domain.exam.exception.ExamHistoryNotFoundException
 import com.gotchai.domain.exam.port.out.ExamCommandPort
@@ -20,6 +23,8 @@ class AdminCommandService(
     private val examHistoryQueryPort: ExamHistoryQueryPort,
     private val examHistoryCommandPort: ExamHistoryCommandPort,
     private val quizHistoryCommandPort: QuizHistoryCommandPort,
+    private val userBadgeQueryPort: UserBadgeQueryPort,
+    private val userBadgeCommandPort: UserBadgeCommandPort,
     private val objectStorageProvider: ObjectStorageProvider
 ) : AdminCommandUseCase {
     @Transactional
@@ -54,5 +59,15 @@ class AdminCommandService(
 
         quizHistoryCommandPort.deleteQuizHistoriesByExamHistoryId(examHistory.id)
         examHistoryCommandPort.deleteExamHistoryByExamIdAndUserId(examId, userId)
+    }
+
+    @Transactional
+    override fun deleteUserBadgeByBadgeIdAndUserId(
+        badgeId: Long,
+        userId: Long
+    ) {
+        val userBadge = userBadgeQueryPort.getUserBadgeByBadgeIdAndUserId(badgeId, userId) ?: throw UserBadgeNotFoundException()
+
+        userBadgeCommandPort.deleteUserBadgeById(userBadge.id)
     }
 }

--- a/domain/src/main/kotlin/com/gotchai/domain/admin/port/in/AdminCommandUseCase.kt
+++ b/domain/src/main/kotlin/com/gotchai/domain/admin/port/in/AdminCommandUseCase.kt
@@ -10,4 +10,9 @@ interface AdminCommandUseCase {
         examId: Long,
         userId: Long
     )
+
+    fun deleteUserBadgeByBadgeIdAndUserId(
+        badgeId: Long,
+        userId: Long
+    )
 }

--- a/domain/src/main/kotlin/com/gotchai/domain/badge/exception/UserBadgeNotFoundException.kt
+++ b/domain/src/main/kotlin/com/gotchai/domain/badge/exception/UserBadgeNotFoundException.kt
@@ -1,0 +1,7 @@
+package com.gotchai.domain.badge.exception
+
+import com.gotchai.domain.global.exception.ServerException
+
+class UserBadgeNotFoundException(
+    override val message: String = "유저가 취득한 뱃지를 찾을 수 없습니다."
+) : ServerException(status = 404, message)

--- a/domain/src/main/kotlin/com/gotchai/domain/badge/port/out/UserBadgeCommandPort.kt
+++ b/domain/src/main/kotlin/com/gotchai/domain/badge/port/out/UserBadgeCommandPort.kt
@@ -4,4 +4,6 @@ import com.gotchai.domain.badge.entity.UserBadge
 
 interface UserBadgeCommandPort {
     fun createUserBadge(creation: UserBadge.Creation): UserBadge
+
+    fun deleteUserBadgeById(id: Long)
 }

--- a/domain/src/main/kotlin/com/gotchai/domain/badge/port/out/UserBadgeQueryPort.kt
+++ b/domain/src/main/kotlin/com/gotchai/domain/badge/port/out/UserBadgeQueryPort.kt
@@ -4,4 +4,9 @@ import com.gotchai.domain.badge.entity.UserBadge
 
 interface UserBadgeQueryPort {
     fun getUserBadgesByUserId(userId: Long): List<UserBadge>
+
+    fun getUserBadgeByBadgeIdAndUserId(
+        badgeId: Long,
+        userId: Long
+    ): UserBadge?
 }

--- a/storage/rdb/src/main/kotlin/com/gotchai/storage/rdb/badge/adapter/out/UserBadgeCommandAdapter.kt
+++ b/storage/rdb/src/main/kotlin/com/gotchai/storage/rdb/badge/adapter/out/UserBadgeCommandAdapter.kt
@@ -12,4 +12,8 @@ class UserBadgeCommandAdapter(
 ) : UserBadgeCommandPort {
     override fun createUserBadge(creation: UserBadge.Creation): UserBadge =
         userBadgeJpaRepository.save(UserBadgeEntity.from(creation)).toUserBadge()
+
+    override fun deleteUserBadgeById(id: Long) {
+        userBadgeJpaRepository.deleteById(id)
+    }
 }

--- a/storage/rdb/src/main/kotlin/com/gotchai/storage/rdb/badge/adapter/out/UserBadgeQueryAdapter.kt
+++ b/storage/rdb/src/main/kotlin/com/gotchai/storage/rdb/badge/adapter/out/UserBadgeQueryAdapter.kt
@@ -2,7 +2,6 @@ package com.gotchai.storage.rdb.badge.adapter.out
 
 import com.gotchai.domain.badge.entity.UserBadge
 import com.gotchai.domain.badge.port.out.UserBadgeQueryPort
-import com.gotchai.storage.rdb.badge.entity.UserBadgeEntity
 import com.gotchai.storage.rdb.badge.repository.UserBadgeJpaRepository
 import com.gotchai.storage.rdb.global.annotation.Adapter
 import com.gotchai.storage.rdb.global.annotation.ReadOnlyTransactional
@@ -15,5 +14,14 @@ class UserBadgeQueryAdapter(
     override fun getUserBadgesByUserId(userId: Long): List<UserBadge> =
         userBadgeRepository
             .findAllByUserId(userId)
-            .map(UserBadgeEntity::toUserBadge)
+            .map { it.toUserBadge() }
+
+    @ReadOnlyTransactional
+    override fun getUserBadgeByBadgeIdAndUserId(
+        badgeId: Long,
+        userId: Long
+    ): UserBadge? =
+        userBadgeRepository
+            .findByBadgeIdAndUserId(badgeId, userId)
+            ?.toUserBadge()
 }

--- a/storage/rdb/src/main/kotlin/com/gotchai/storage/rdb/badge/repository/UserBadgeJpaRepository.kt
+++ b/storage/rdb/src/main/kotlin/com/gotchai/storage/rdb/badge/repository/UserBadgeJpaRepository.kt
@@ -4,5 +4,10 @@ import com.gotchai.storage.rdb.badge.entity.UserBadgeEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface UserBadgeJpaRepository : JpaRepository<UserBadgeEntity, Long> {
+    fun findByBadgeIdAndUserId(
+        badgeId: Long,
+        userId: Long
+    ): UserBadgeEntity?
+
     fun findAllByUserId(userId: Long): List<UserBadgeEntity>
 }


### PR DESCRIPTION
## 관련 이슈
- close #124

## 작업 사항
- 유저 뱃지 삭제 API 구현

## 설명
- 테스트 기록 초기화 API 사용 시 뱃지 무결성을 보장하기 위해 구현한 API입니다.